### PR TITLE
repo: Improve GitHub image download

### DIFF
--- a/developer_disk_image/repo.py
+++ b/developer_disk_image/repo.py
@@ -1,12 +1,11 @@
-import base64
 import dataclasses
 import json
 from datetime import datetime, timezone
-from typing import Mapping, Optional
+from typing import Mapping, Optional, Union
 
 import requests
 
-from developer_disk_image.exceptions import GithubRateLimitExceededError
+from developer_disk_image.exceptions import GithubRateLimitExceededError, DeveloperDiskImageException
 
 DEVELOPER_DISK_IMAGE_REPO_TREE_URL = \
     'https://api.github.com/repos/doronz88/DeveloperDiskImage/git/trees/main?recursive=true'
@@ -27,8 +26,9 @@ class PersonalizedImage:
 
 class DeveloperDiskImageRepository:
     @classmethod
-    def create(cls) -> 'DeveloperDiskImageRepository':
-        return cls(cls._query(DEVELOPER_DISK_IMAGE_REPO_TREE_URL)['tree'])
+    def create(cls, github_token: Optional[str] = None) -> 'DeveloperDiskImageRepository':
+        tree = cls._query(DEVELOPER_DISK_IMAGE_REPO_TREE_URL, github_token=github_token)['tree']
+        return cls(tree, github_token=github_token)
 
     def __init__(self, tree: Mapping, github_token: Optional[str] = None):
         self._path_urls = {}
@@ -56,23 +56,30 @@ class DeveloperDiskImageRepository:
         url = self._path_urls.get(path, {}).get('url')
         if url is None:
             return None
-        return base64.b64decode(self._query(url, github_token=self.github_token)['content'])
+        return self._query(url, raw=True, github_token=self.github_token)
 
     @staticmethod
-    def _query(url: str, github_token: Optional[str] = None) -> Mapping:
-        headers = {}
+    def _query(url: str, raw: bool = False, github_token: Optional[str] = None) -> Union[Mapping, bytes]:
+        headers = {
+            'X-GitHub-Api-Version': '2022-11-28',
+            'Accept': 'application/vnd.github.raw+json' if raw else 'application/vnd.github+json'
+        }
         if github_token is not None:
-            headers = {
-                'Accept': 'application/vnd.github+json',
-                'Authorization': 'Bearer ' + github_token,
-                'X-GitHub-Api-Version': '2022-11-28'
-            }
+            headers['Authorization'] = 'Bearer ' + github_token
         response = requests.get(url, headers=headers)
-        content = json.loads(response.text)
-        if content.get('message', '').startswith('API rate limit exceeded'):
-            reset_time = int(response.headers['X-RateLimit-Reset'])
-            reset_utc = datetime.fromtimestamp(reset_time, timezone.utc)
-            reset_local = reset_utc.astimezone()
-            raise GithubRateLimitExceededError(
-                f'GitHub API rate limit exceeded. Wait until {reset_local} or use a custom GitHub access token')
-        return content
+        status_code = response.status_code
+        if status_code != 200:
+            # https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit
+            if (status_code == 403 or status_code == 429) and int(response.headers['x-ratelimit-remaining']) == 0:
+                reset_time = int(response.headers['x-ratelimit-reset'])
+                reset_utc = datetime.fromtimestamp(reset_time, timezone.utc)
+                reset_local = reset_utc.astimezone()
+                raise GithubRateLimitExceededError(
+                    f'GitHub API: rate limit exceeded. Wait until {reset_local} or use a custom GitHub access token')
+            raise DeveloperDiskImageException(f'GitHub API: request failed: {response.status_code}')
+        if raw:
+            content = response.content
+            if content is None:
+                DeveloperDiskImageException('GitHub API: no content returned')
+            return content
+        return json.loads(response.text)


### PR DESCRIPTION
* allow specifying github_token in `create()`
* downloading image files from GitHub improved (download directly as binary instead of base64)
* detection of API rate limit exceeded errors improved as defined in GitHub documentation https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit
* fail if HTTP status code is not 200 (other problems)